### PR TITLE
upload images as batches

### DIFF
--- a/notebooks/azureml-labels-to-custom-vision.ipynb
+++ b/notebooks/azureml-labels-to-custom-vision.ipynb
@@ -273,7 +273,9 @@
    "outputs": [],
    "source": [
     "print(\"Uploading images and tags\")\n",
-    "trainer.create_images_from_files(project.id, images=tagged_ims)\n",
+    "for i in range(0, len(tagged_ims), 64):   \n",
+    "    batch = tagged_ims[i:i+64]\n",
+    "    trainer.create_images_from_files(project.id, images=batch)\n",
     "\n",
     "# clean up temp directory\n",
     "shutil.rmtree(tmp_dir)"


### PR DESCRIPTION
In this PR:
-upload images in batches of 64 to custom vision service 

closes #9 